### PR TITLE
bug fix for `suggest_moves`

### DIFF
--- a/players/g3_player.py
+++ b/players/g3_player.py
@@ -188,6 +188,7 @@ class DensityMap:
         to scale attraction force of allies and enemies. TODO: a better metric for scale.
         """
 
+        ally_pos = np.array(ally_pos)
         grid_id = self.pt2grid(ally_pos[0], ally_pos[1])
         troops = self.soldier_partitions[grid_id]
         ally2enemy_ratio = reduce(
@@ -204,11 +205,11 @@ class DensityMap:
 
         attr_fvec = np.zeros((2,), dtype=float)
         for other_soldier, pid in troops:
-            if (other_soldier != ally_pos).all():
+            if not (other_soldier == ally_pos).all():
                 attr_scale = ally_attr_scale if pid == self.me else enemy_attr_scale
                 attr_fvec += attr_scale * attractive_force(ally_pos, other_soldier)
 
-        angle = np.arctan2(attr_fvec[0], attr_fvec[1])
+        angle = np.arctan2(attr_fvec[1], attr_fvec[0])
 
         return (1, angle)
 


### PR DESCRIPTION
previously, suggest moves not working as expected.

![inverse_sq_scale_before](https://user-images.githubusercontent.com/25857014/195961617-6a2bb99f-f17d-4f96-983e-e3a6e8119c7a.png)
> - blue dots and red dots represent allies and enemies in a 10*10 grid at the current turn
> - green dots represent allies in the next turn after apply (dist, angle) from `suggest_moves`
>
> In this specific case, we should expect both clusters to move towards the enemies, but the cluster on the left hand side is moving away.


After fixing 2 trivial bugs, player is behaving as expected:
![inverse_sq_scale_after](https://user-images.githubusercontent.com/25857014/195961618-1f5759bc-b553-40ee-bc25-3daa1d6637b3.png)